### PR TITLE
Default options for search delay (Close #7)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: searcher
 Title: Query Search Interfaces 
-Version: 0.0.4
+Version: 0.0.5
 Authors@R: c(
              person("James", "Balamuta",
                     email = "balamut2@illinois.edu", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# searcher 0.0.5
+
+## Features
+
+- Added ability to set default package actions.
+  - `searcher.launch_delay` controls how long the user remains in _R_ prior
+    to the browser opening. 
+
 # searcher 0.0.4
 
 ## Features

--- a/R/searcher-package.R
+++ b/R/searcher-package.R
@@ -1,4 +1,30 @@
 #' @aliases searcher-package
-#' @details
-#' Provides an interface to search engines via R.
+#' @section Package Customizations:
+#'
+#' `searcher` accesses a set of default values stored in [options()] on each
+#' call to keep the function signatures small. By default, these options are given as:
+#'
+#' - `searcher.launch_delay`: Amount of time to remain in _R_ before opening
+#'    a browser window. Default is 0.5 seconds.
+#' - ...
+#'
 "_PACKAGE"
+
+searcher_default_options = list(
+  searcher.launch_delay = 0.5
+)
+
+.onLoad = function(libname, pkgname) {
+  # Retrieve options
+  options_active = options()
+
+  # Determine if defaults are missing
+  missing_defaults = !(names(searcher_default_options) %in% names(options_active))
+
+  # Set any missing default options
+  if (any(missing_defaults)) {
+    options(searcher_default_options[missing_defaults])
+  }
+
+  invisible()
+}

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -30,10 +30,13 @@ browse_url = function(base,
 
   encodedURL = paste0(base, utils::URLencode(unencoded_query), encoded_query)
 
+
   if (open_browser) {
     message("Searching query in web browser ... ")
-    Sys.sleep(0.5)
+
+    Sys.sleep(getOption("searcher.launch_delay"))
     utils::browseURL(encodedURL)
+
   } else {
     message("Please type into your browser: \n", invisible(encodedURL))
   }

--- a/README.Rmd
+++ b/README.Rmd
@@ -137,6 +137,32 @@ search_github()            # or search_gh()
 search_bitbucket()         # or search_bb()
 ```
 
+## Package Customizations
+
+The ability to customize different operations in `searcher` is possible by
+setting values in [`options()`](https://stat.ethz.ch/R-manual/R-patched/RHOME/library/base/html/options.html)
+within [`~/.Rprofile`](https://stat.ethz.ch/R-manual/R-patched/library/base/html/Startup.html).
+Presently, the following options are available:
+
+- `searcher.launch_delay`: Amount of time between launching the web browser
+  from when the command was issued. Default is `0.5` seconds.
+
+To set one of these options, please create the `.Rprofile` by typing into _R_:
+
+```r
+file.edit("~/.Rprofile")
+```
+
+From there, add:
+
+```r
+.First = function() {
+  options(
+    searcher.launch_delay = 0
+    ## Additional options.
+  )
+}
+```
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,36 @@ search_github()            # or search_gh()
 search_bitbucket()         # or search_bb()
 ```
 
+## Package Customizations
+
+The ability to customize different operations in `searcher` is possible
+by setting values in
+[`options()`](https://stat.ethz.ch/R-manual/R-patched/RHOME/library/base/html/options.html)
+within
+[`~/.Rprofile`](https://stat.ethz.ch/R-manual/R-patched/library/base/html/Startup.html).
+Presently, the following options are available:
+
+  - `searcher.launch_delay`: Amount of time between launching the web
+    browser from when the command was issued. Default is `0.5` seconds.
+
+To set one of these options, please create the `.Rprofile` by typing
+into *R*:
+
+``` r
+file.edit("~/.Rprofile")
+```
+
+From there, add:
+
+``` r
+.First = function() {
+  options(
+    searcher.launch_delay = 0
+    ## Additional options.
+  )
+}
+```
+
 ## Motivation
 
 The idea for `searcher` began as a project to automatically search

--- a/man/searcher-package.Rd
+++ b/man/searcher-package.Rd
@@ -11,9 +11,18 @@ Provides a search interface to look up terms
     'RStudio Community', 'GitHub', and 'BitBucket'. Upon searching, a browser 
     window will open with the aforementioned search results.
 }
-\details{
-Provides an interface to search engines via R.
+\section{Package Customizations}{
+
+
+\code{searcher} accesses a set of default values stored in \code{\link[=options]{options()}} on each
+call to keep the function signatures small. By default, these options are given as:
+\itemize{
+\item \code{searcher.launch_delay}: Amount of time to remain in \emph{R} before opening
+a browser window. Default is 0.5 seconds.
+\item ...
 }
+}
+
 \seealso{
 Useful links:
 \itemize{


### PR DESCRIPTION
Provides a mechanism for overriding the self-imposed `0.5` second delay on opening the URL in a web browser.

Close #7