### PR TITLE
Enable search queries to show up in RStudio's Viewer Panel (close #21)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,18 @@
 ## Features
 
 - Added ability to set default package actions.
+- Allow RStudio's Viewer pane to display search results.
+  - Note: This feature requires a patch per [issue 2252](https://github.com/rstudio/rstudio/issues/2252).
+
+## Changes
+
+- Default options added.
   - `searcher.launch_delay` controls how long the user remains in _R_ prior
-    to the browser opening. 
+    to the browser opening. Default is `0.5` seconds.
+  - `searcher.use_rstudio_viewer` specifies whether RStudio's viewer pane should
+    open the link instead of a web browser. Default is `FALSE` until the issue
+    is resolved..
+
 
 # searcher 0.0.4
 

--- a/R/searcher-package.R
+++ b/R/searcher-package.R
@@ -5,13 +5,16 @@
 #' call to keep the function signatures small. By default, these options are given as:
 #'
 #' - `searcher.launch_delay`: Amount of time to remain in _R_ before opening
-#'    a browser window. Default is 0.5 seconds.
+#'    a browser window. Default is `0.5` seconds.
+#' - `searcher.use_rstudio_viewer`: Display search results in the RStudio
+#'    viewer pane instead of a web browser. Default is `TRUE`.
 #' - ...
 #'
 "_PACKAGE"
 
 searcher_default_options = list(
-  searcher.launch_delay = 0.5
+  searcher.launch_delay = 0.5,
+  searcher.use_rstudio_viewer = TRUE
 )
 
 .onLoad = function(libname, pkgname) {

--- a/R/searcher-package.R
+++ b/R/searcher-package.R
@@ -7,14 +7,14 @@
 #' - `searcher.launch_delay`: Amount of time to remain in _R_ before opening
 #'    a browser window. Default is `0.5` seconds.
 #' - `searcher.use_rstudio_viewer`: Display search results in the RStudio
-#'    viewer pane instead of a web browser. Default is `TRUE`.
+#'    viewer pane instead of a web browser. Default is `FALSE`.
 #' - ...
 #'
 "_PACKAGE"
 
 searcher_default_options = list(
   searcher.launch_delay = 0.5,
-  searcher.use_rstudio_viewer = TRUE
+  searcher.use_rstudio_viewer = FALSE
 )
 
 .onLoad = function(libname, pkgname) {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -5,12 +5,14 @@
 #' @param base             The URL prefix e.g. `https://google.com/search?q=`
 #' @param unencoded_query  An unencoded string that must be encoded with [utils::URLencode()].
 #' @param encoded_query    An encoded string that satisifies [utils::URLencode()].
-#' @param open_browser     Should the URL be opened in a web browser.
-#' @inheritParams utils::browseURL
+#' @param open_browser  Should the URL be opened in a web browser.
 #'
-#' @return A `character` object containing the query URL
+#' @return
+#' A `character` object containing the query URL
 #'
-#' @seealso [utils::browseURL()], [utils::URLencode()]
+#' @seealso
+#' [utils::browseURL()]
+#'
 #' @examples
 #' # Query Google
 #' browse_url("https://google.com/search?q=", "rstats is great")
@@ -25,26 +27,54 @@
 #' @noRd
 browse_url = function(base,
                       unencoded_query, encoded_query = "",
-                      browser = getOption("browser"),
                       open_browser = interactive()) {
 
-  encodedURL = paste0(base, utils::URLencode(unencoded_query), encoded_query)
-
-
+  url = encode_url(base, unencoded_query, encoded_query)
   if (open_browser) {
-    message("Searching query in web browser ... ")
-
-    Sys.sleep(getOption("searcher.launch_delay"))
-    utils::browseURL(encodedURL)
-
+    if (is_rstudio() && getOption("searcher.use_rstudio_viewer")) {
+      open_rstudio_viewer(url)
+    } else {
+      open_browser(url)
+    }
   } else {
-    message("Please type into your browser: \n", invisible(encodedURL))
+    message("Please type into your browser:\n", invisible(url))
   }
 
-  invisible(encodedURL)
+  invisible(url)
 }
 
+open_rstudio_viewer = function(url) {
+  message("Searching query in RStudio's Viewer panel ... ")
+  Sys.sleep(getOption("searcher.launch_delay"))
 
+  # If in RStudio, this should be set.
+  viewer <- getOption("viewer")
+  viewer(url)
+}
+
+open_browser = function(url) {
+  message("Searching query in a web browser ... ")
+  Sys.sleep(getOption("searcher.launch_delay"))
+  utils::browseURL(url)
+}
+
+#' Form Encoded URL
+#'
+#' Creates a URL with appropriate encoding
+#'
+#' @param base             The URL prefix e.g. `https://google.com/search?q=`
+#' @param unencoded_query  An unencoded string that must be encoded with [utils::URLencode()].
+#' @param encoded_query    An encoded string that satisifies [utils::URLencode()].
+#'
+#' @return
+#' A properly formatted URL.
+#'
+#' @seealso
+#' [utils::URLencode()]
+#' @noRd
+encode_url = function(base, unencoded_query, encoded_query = "") {
+  paste0(base, utils::URLencode(unencoded_query), encoded_query)
+}
 
 #' Validate search query
 #'
@@ -99,4 +129,21 @@ append_r_suffix = function(query, rlang = TRUE, suffix = "r programming") {
     paste(query, suffix)
   else
     query
+}
+
+#' Check if in RStudio
+#'
+#' Verifies whether the user is using the RStudio IDE.
+#'
+#' @return
+#' A `logical` value indicating whether _R_ is being accessed from the RStudio
+#' IDE.
+#'
+#' @examples
+#' # Check if in RStudio
+#' is_rstudio()
+#'
+#' @noRd
+is_rstudio = function() {
+  Sys.getenv("RSTUDIO") == "1"
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -147,7 +147,7 @@ Presently, the following options are available:
 - `searcher.launch_delay`: Amount of time between launching the web browser
   from when the command was issued. Default is `0.5` seconds.
 - `searcher.use_rstudio_viewer`: Display search results in the RStudio
-   viewer pane instead of a web browser. Default is `TRUE`.
+   viewer pane instead of a web browser. Default is `FALSE`.
 
 To set one of these options, please create the `.Rprofile` by typing into _R_:
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -146,6 +146,8 @@ Presently, the following options are available:
 
 - `searcher.launch_delay`: Amount of time between launching the web browser
   from when the command was issued. Default is `0.5` seconds.
+- `searcher.use_rstudio_viewer`: Display search results in the RStudio
+   viewer pane instead of a web browser. Default is `TRUE`.
 
 To set one of these options, please create the `.Rprofile` by typing into _R_:
 
@@ -158,7 +160,8 @@ From there, add:
 ```r
 .First = function() {
   options(
-    searcher.launch_delay = 0
+    searcher.launch_delay       = 0,
+    searcher.use_rstudio_viewer = FALSE
     ## Additional options.
   )
 }

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Presently, the following options are available:
 
   - `searcher.launch_delay`: Amount of time between launching the web
     browser from when the command was issued. Default is `0.5` seconds.
+  - `searcher.use_rstudio_viewer`: Display search results in the RStudio
+    viewer pane instead of a web browser. Default is `TRUE`.
 
 To set one of these options, please create the `.Rprofile` by typing
 into *R*:
@@ -159,7 +161,8 @@ From there, add:
 ``` r
 .First = function() {
   options(
-    searcher.launch_delay = 0
+    searcher.launch_delay       = 0,
+    searcher.use_rstudio_viewer = FALSE
     ## Additional options.
   )
 }

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Presently, the following options are available:
   - `searcher.launch_delay`: Amount of time between launching the web
     browser from when the command was issued. Default is `0.5` seconds.
   - `searcher.use_rstudio_viewer`: Display search results in the RStudio
-    viewer pane instead of a web browser. Default is `TRUE`.
+    viewer pane instead of a web browser. Default is `FALSE`.
 
 To set one of these options, please create the `.Rprofile` by typing
 into *R*:

--- a/man/searcher-package.Rd
+++ b/man/searcher-package.Rd
@@ -20,7 +20,7 @@ call to keep the function signatures small. By default, these options are given 
 \item \code{searcher.launch_delay}: Amount of time to remain in \emph{R} before opening
 a browser window. Default is \code{0.5} seconds.
 \item \code{searcher.use_rstudio_viewer}: Display search results in the RStudio
-viewer pane instead of a web browser. Default is \code{TRUE}.
+viewer pane instead of a web browser. Default is \code{FALSE}.
 \item ...
 }
 }

--- a/man/searcher-package.Rd
+++ b/man/searcher-package.Rd
@@ -18,7 +18,9 @@ Provides a search interface to look up terms
 call to keep the function signatures small. By default, these options are given as:
 \itemize{
 \item \code{searcher.launch_delay}: Amount of time to remain in \emph{R} before opening
-a browser window. Default is 0.5 seconds.
+a browser window. Default is \code{0.5} seconds.
+\item \code{searcher.use_rstudio_viewer}: Display search results in the RStudio
+viewer pane instead of a web browser. Default is \code{TRUE}.
 \item ...
 }
 }


### PR DESCRIPTION
This PR addresses the ability to use RStudio's [viewer pane](https://support.rstudio.com/hc/en-us/articles/202133558-Extending-RStudio-with-the-Viewer-Pane) for results when available.
We've disabled this option by default as RStudio's viewer pane does not correctly apply sandboxing, c.f. rstudio/rstudio#2252

Close #21 

**Note:** We've avoided adding a dependency on [`rstudioapi`](https://github.com/rstudio/rstudioapi) to work with the viewer. 